### PR TITLE
Add support for building using Alire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/obj/
+/bin/
+/alire/
+/config/

--- a/alire.toml
+++ b/alire.toml
@@ -9,3 +9,7 @@ maintainers-logins = ["mgrojo"]
 executables = ["main"]
 [[depends-on]]
 gtkada = "^21.0.0"
+[[depends-on]]
+openal_ada = "^1.1.1-dev"
+[[pins]]
+openal_ada = { path='../../io7m/coreland-openal-ada' }

--- a/alire.toml
+++ b/alire.toml
@@ -1,0 +1,11 @@
+name = "doppler_effect"
+description = "Moving airplane causes Stereo Sound Doppler effect."
+version = "0.1.0-dev"
+
+authors = ["moriyasum"]
+maintainers = ["Manuel Gomez <mgrojo@gmail.com>"]
+maintainers-logins = ["mgrojo"]
+
+executables = ["main"]
+[[depends-on]]
+gtkada = "^21.0.0"

--- a/doppler_effect.gpr
+++ b/doppler_effect.gpr
@@ -1,5 +1,4 @@
 with "config/doppler_effect_config.gpr";
-with "../../io7m/coreland-openal-ada/openal_ada.gpr";
 
 project Doppler_Effect is
 

--- a/doppler_effect.gpr
+++ b/doppler_effect.gpr
@@ -1,0 +1,24 @@
+with "config/doppler_effect_config.gpr";
+with "../../io7m/coreland-openal-ada/openal_ada.gpr";
+
+project Doppler_Effect is
+
+   for Source_Dirs use ("src/", "config/");
+   for Object_Dir use "obj/" & Doppler_Effect_Config.Build_Profile;
+   for Create_Missing_Dirs use "True";
+   for Exec_Dir use "obj/";
+   for Main use ("main.adb");
+
+   package Compiler is
+      for Default_Switches ("Ada") use Doppler_Effect_Config.Ada_Compiler_Switches;
+   end Compiler;
+
+   package Binder is
+      for Switches ("Ada") use ("-Es"); --  Symbolic traceback
+   end Binder;
+
+   package Install is
+      for Artifacts (".") use ("share");
+   end Install;
+
+end Doppler_Effect;


### PR DESCRIPTION
This currently depends on the presence of a version of openal-ada on ../../io7m/coreland-openal-ada/ and built using Alire.

See issue #1